### PR TITLE
asterisk-sounds-core.spec: create Asterisk home when creating asterisk user

### DIFF
--- a/asterisk-sounds-core.spec
+++ b/asterisk-sounds-core.spec
@@ -272,88 +272,88 @@ This package contains Asterisk core sounds - en_GB - alaw.
 This package contains Asterisk core sounds - en_GB - sln16.
 
 %pre en-ulaw
-groupadd -f asterisk
-useradd -r -M -s /bin/bash -d /home/asterisk asterisk 2> /dev/null || :
+%{_sbindir}/groupadd -r asterisk &>/dev/null || :
+%{_sbindir}/useradd -r -s /bin/bash -d /home/asterisk -c 'Asterisk User' -g asterisk asterisk &>/dev/null || :
 
 %pre en-alaw
-groupadd -f asterisk
-useradd -r -M -s /bin/bash -d /home/asterisk asterisk 2> /dev/null || :
+%{_sbindir}/groupadd -r asterisk &>/dev/null || :
+%{_sbindir}/useradd -r -s /bin/bash -d /home/asterisk -c 'Asterisk User' -g asterisk asterisk &>/dev/null || :
 
 %pre en-wideband
-groupadd -f asterisk
-useradd -r -M -s /bin/bash -d /home/asterisk asterisk 2> /dev/null || :
+%{_sbindir}/groupadd -r asterisk &>/dev/null || :
+%{_sbindir}/useradd -r -s /bin/bash -d /home/asterisk -c 'Asterisk User' -g asterisk asterisk &>/dev/null || :
 
 %pre en_AU-ulaw
-groupadd -f asterisk
-useradd -r -M -s /bin/bash -d /home/asterisk asterisk 2> /dev/null || :
+%{_sbindir}/groupadd -r asterisk &>/dev/null || :
+%{_sbindir}/useradd -r -s /bin/bash -d /home/asterisk -c 'Asterisk User' -g asterisk asterisk &>/dev/null || :
 
 %pre en_AU-alaw
-groupadd -f asterisk
-useradd -r -M -s /bin/bash -d /home/asterisk asterisk 2> /dev/null || :
+%{_sbindir}/groupadd -r asterisk &>/dev/null || :
+%{_sbindir}/useradd -r -s /bin/bash -d /home/asterisk -c 'Asterisk User' -g asterisk asterisk &>/dev/null || :
 
 %pre en_AU-wideband
-groupadd -f asterisk
-useradd -r -M -s /bin/bash -d /home/asterisk asterisk 2> /dev/null || :
+%{_sbindir}/groupadd -r asterisk &>/dev/null || :
+%{_sbindir}/useradd -r -s /bin/bash -d /home/asterisk -c 'Asterisk User' -g asterisk asterisk &>/dev/null || :
 
 %pre es-ulaw
-groupadd -f asterisk
-useradd -r -M -s /bin/bash -d /home/asterisk asterisk 2> /dev/null || :
+%{_sbindir}/groupadd -r asterisk &>/dev/null || :
+%{_sbindir}/useradd -r -s /bin/bash -d /home/asterisk -c 'Asterisk User' -g asterisk asterisk &>/dev/null || :
 
 %pre es-alaw
-groupadd -f asterisk
-useradd -r -M -s /bin/bash -d /home/asterisk asterisk 2> /dev/null || :
+%{_sbindir}/groupadd -r asterisk &>/dev/null || :
+%{_sbindir}/useradd -r -s /bin/bash -d /home/asterisk -c 'Asterisk User' -g asterisk asterisk &>/dev/null || :
 
 %pre es-wideband
-groupadd -f asterisk
-useradd -r -M -s /bin/bash -d /home/asterisk asterisk 2> /dev/null || :
+%{_sbindir}/groupadd -r asterisk &>/dev/null || :
+%{_sbindir}/useradd -r -s /bin/bash -d /home/asterisk -c 'Asterisk User' -g asterisk asterisk &>/dev/null || :
 
 %pre fr-ulaw
-groupadd -f asterisk
-useradd -r -M -s /bin/bash -d /home/asterisk asterisk 2> /dev/null || :
+%{_sbindir}/groupadd -r asterisk &>/dev/null || :
+%{_sbindir}/useradd -r -s /bin/bash -d /home/asterisk -c 'Asterisk User' -g asterisk asterisk &>/dev/null || :
 
 %pre fr-alaw
-groupadd -f asterisk
-useradd -r -M -s /bin/bash -d /home/asterisk asterisk 2> /dev/null || :
+%{_sbindir}/groupadd -r asterisk &>/dev/null || :
+%{_sbindir}/useradd -r -s /bin/bash -d /home/asterisk -c 'Asterisk User' -g asterisk asterisk &>/dev/null || :
 
 %pre fr-wideband
-groupadd -f asterisk
-useradd -r -M -s /bin/bash -d /home/asterisk asterisk 2> /dev/null || :
+%{_sbindir}/groupadd -r asterisk &>/dev/null || :
+%{_sbindir}/useradd -r -s /bin/bash -d /home/asterisk -c 'Asterisk User' -g asterisk asterisk &>/dev/null || :
 
 %pre ja-ulaw
-groupadd -f asterisk
-useradd -r -M -s /bin/bash -d /home/asterisk asterisk 2> /dev/null || :
+%{_sbindir}/groupadd -r asterisk &>/dev/null || :
+%{_sbindir}/useradd -r -s /bin/bash -d /home/asterisk -c 'Asterisk User' -g asterisk asterisk &>/dev/null || :
 
 %pre ja-alaw
-groupadd -f asterisk
-useradd -r -M -s /bin/bash -d /home/asterisk asterisk 2> /dev/null || :
+%{_sbindir}/groupadd -r asterisk &>/dev/null || :
+%{_sbindir}/useradd -r -s /bin/bash -d /home/asterisk -c 'Asterisk User' -g asterisk asterisk &>/dev/null || :
 
 %pre ja-wideband
-groupadd -f asterisk
-useradd -r -M -s /bin/bash -d /home/asterisk asterisk 2> /dev/null || :
+%{_sbindir}/groupadd -r asterisk &>/dev/null || :
+%{_sbindir}/useradd -r -s /bin/bash -d /home/asterisk -c 'Asterisk User' -g asterisk asterisk &>/dev/null || :
 
 %pre it-ulaw
-groupadd -f asterisk
-useradd -r -M -s /bin/bash -d /home/asterisk asterisk 2> /dev/null || :
+%{_sbindir}/groupadd -r asterisk &>/dev/null || :
+%{_sbindir}/useradd -r -s /bin/bash -d /home/asterisk -c 'Asterisk User' -g asterisk asterisk &>/dev/null || :
 
 %pre it-alaw
-groupadd -f asterisk
-useradd -r -M -s /bin/bash -d /home/asterisk asterisk 2> /dev/null || :
+%{_sbindir}/groupadd -r asterisk &>/dev/null || :
+%{_sbindir}/useradd -r -s /bin/bash -d /home/asterisk -c 'Asterisk User' -g asterisk asterisk &>/dev/null || :
 
 %pre it-wideband
-groupadd -f asterisk
-useradd -r -M -s /bin/bash -d /home/asterisk asterisk 2> /dev/null || :
+%{_sbindir}/groupadd -r asterisk &>/dev/null || :
+%{_sbindir}/useradd -r -s /bin/bash -d /home/asterisk -c 'Asterisk User' -g asterisk asterisk &>/dev/null || :
 
 %pre en_GB-ulaw
-groupadd -f asterisk
-useradd -r -M -s /bin/bash -d /home/asterisk asterisk 2> /dev/null || :
+%{_sbindir}/groupadd -r asterisk &>/dev/null || :
+%{_sbindir}/useradd -r -s /bin/bash -d /home/asterisk -c 'Asterisk User' -g asterisk asterisk &>/dev/null || :
 
 %pre en_GB-alaw
-groupadd -f asterisk
-useradd -r -M -s /bin/bash -d /home/asterisk asterisk 2> /dev/null || :
+%{_sbindir}/groupadd -r asterisk &>/dev/null || :
+%{_sbindir}/useradd -r -s /bin/bash -d /home/asterisk -c 'Asterisk User' -g asterisk asterisk &>/dev/null || :
 
 %pre en_GB-wideband
-groupadd -f asterisk
-useradd -r -M -s /bin/bash -d /home/asterisk asterisk 2> /dev/null || :
+%{_sbindir}/groupadd -r asterisk &>/dev/null || :
+%{_sbindir}/useradd -r -s /bin/bash -d /home/asterisk -c 'Asterisk User' -g asterisk asterisk &>/dev/null || :
 
 %prep
 

--- a/asterisk-sounds-core.spec
+++ b/asterisk-sounds-core.spec
@@ -4,7 +4,7 @@
 Summary: Core Sounds for Asterisk, The Open Source PBX
 Name: asterisk-sounds-core
 Version: 1.5
-Release: 2%{dist}
+Release: 3%{dist}
 License: GPL
 Group: Utilities/System
 Source10: http://downloads.digium.com/pub/telephony/sounds/releases/asterisk-core-sounds-en-ulaw-%{version}.tar.gz
@@ -654,3 +654,7 @@ cd $RPM_BUILD_DIR
 %attr(0664,asterisk,asterisk) /var/lib/asterisk/sounds/en_GB/CREDITS-asterisk-core-en_GB-%{version}
 %attr(0664,asterisk,asterisk) /var/lib/asterisk/sounds/en_GB/LICENSE-asterisk-core-en_GB-%{version}
 %attr(0664,asterisk,asterisk) /var/lib/asterisk/sounds/.asterisk-core-sounds-en_GB-sln16-%{version}
+
+%changelog
+* Wed Nov 15 2017 Stefano Fancello <stefano.fancello@nethesis.it> 1.5-3
+- Create Asterisk home when creating asterisk user


### PR DESCRIPTION
this should be useless because Asterisk home is already created by Asterisk package, but there's no point of not creating it to have it created afterwards